### PR TITLE
Bugfix/emp3 web#88 map.set mil std labels not working

### DIFF
--- a/src/mapengine/cesium/js/cesium-map-engine.debug.js
+++ b/src/mapengine/cesium/js/cesium-map-engine.debug.js
@@ -2154,6 +2154,7 @@ emp.engineDefs.cesiumMapEngine = function (args)
                         // array.  Index it by the value of the label, so we can
                         // do an easy lookup later.  Just set the value to true
                         // so it equals something.
+                        newMilStdIconLabelSetting = [];
                         for (i = 0; i < milStdIconLabels.length; i += 1)
                         {
                             newMilStdIconLabelSetting[milStdIconLabels[i]] = true;

--- a/src/mapengine/cesium/js/cesium-map-engine.debug.js
+++ b/src/mapengine/cesium/js/cesium-map-engine.debug.js
@@ -541,7 +541,7 @@ emp.engineDefs.cesiumMapEngine = function (args)
                 }
             }
         }
-         empCesium.redrawGraphics();
+        empCesium.redrawGraphics();
         if (failList.length > 0)
         {
             transaction.fail(failList);
@@ -708,7 +708,7 @@ emp.engineDefs.cesiumMapEngine = function (args)
                     }
                 }
             }
-             empCesium.redrawGraphics();
+            empCesium.redrawGraphics();
             if (failList.length > 0)
             {
                 transaction.fail(failList);
@@ -2034,7 +2034,8 @@ emp.engineDefs.cesiumMapEngine = function (args)
     {
         engineInterface.map.config = function (transaction)
         {
-            var singlePointKey,
+            var singlePointKey, milStdIconLabels, newMilStdIconLabelSetting,
+                    drawCountryCodeChanged,
                     bRangeChanged = false,
                     iconSizeChanged = false,
                     bSelectionStyleChanged = false;
@@ -2127,6 +2128,78 @@ emp.engineDefs.cesiumMapEngine = function (args)
                                 if (!empCesium.isSinglePointIdOnHoldPresent(singlePointKey))
                                 {
                                     empCesium.throttleMil2525IconSizeSet(singlePointKey);
+                                }
+                            }
+                        }
+                    }
+
+                    if (empCesium.defined(config.milStdIconLabels))
+                    {
+                        // Retrieve the array of labels that are turned on from the
+                        // transaction.
+                        milStdIconLabels = config.milStdIconLabels;
+                        if (milStdIconLabels && milStdIconLabels.length <= 6)
+                        {
+                            empCesium.iconLabelOption = "none";
+                        }
+                        else if (milStdIconLabels && milStdIconLabels.length <= 12)
+                        {
+                            empCesium.iconLabelOption = "common";
+                        }
+                        else if (milStdIconLabels && milStdIconLabels.length > 12)
+                        {
+                            empCesium.iconLabelOption = "all";
+                        }
+                        // Loop through the array of labels, and store in an
+                        // array.  Index it by the value of the label, so we can
+                        // do an easy lookup later.  Just set the value to true
+                        // so it equals something.
+                        for (i = 0; i < milStdIconLabels.length; i += 1)
+                        {
+                            newMilStdIconLabelSetting[milStdIconLabels[i]] = true;
+                        }
+
+                        if (newMilStdIconLabelSetting && newMilStdIconLabelSetting.hasOwnProperty("CC"))
+                        {
+                            drawCountryCodeChanged = empCesium.drawCountryCode === false;
+                            empCesium.drawCountryCode = true;
+                            armyc2.c2sd.renderer.utilities.RendererSettings.setDrawCountryCode(empCesium.drawCountryCode);
+                        }
+                        else
+                        {
+                            drawCountryCodeChanged = empCesium.drawCountryCode === true;
+                            empCesium.drawCountryCode = false;
+                            armyc2.c2sd.renderer.utilities.RendererSettings.setDrawCountryCode(empCesium.drawCountryCode);
+                        }
+
+                        // Assign the class level variable.
+                        empCesium.iconLabels = newMilStdIconLabelSetting;
+                        //check altitude range mode before calling the throttlering. If icon label option is none 
+                        //and the range mode is mid or high then there is no need to render because teh icons are already with no labels.
+                        if (empCesium.iconLabelOption === "none" && (empCesium.singlePointAltitudeRangeMode === EmpCesiumConstants.SinglePointAltitudeRangeMode.MID_RANGE ||
+                                empCesium.singlePointAltitudeRangeMode === EmpCesiumConstants.SinglePointAltitudeRangeMode.HIGHEST_RANGE) && empCesium.enableRenderingOptimization && !drawCountryCodeChanged)
+                        {
+                            // do nothing. single points already with no labels and CC enabling not changed
+                            //console.log(empCesium.iconLabelOption);
+                            // console.log(empCesium.singlePointAltitudeRangeMode);
+                        }
+                        else if ((empCesium.iconLabelOption === "common" || empCesium.iconLabelOption === "all") &&
+                                (empCesium.singlePointAltitudeRangeMode === EmpCesiumConstants.SinglePointAltitudeRangeMode.MID_RANGE ||
+                                        empCesium.singlePointAltitudeRangeMode === EmpCesiumConstants.SinglePointAltitudeRangeMode.HIGHEST_RANGE) && empCesium.enableRenderingOptimization && !drawCountryCodeChanged)
+                        {
+                            // do nothing. single points are at a range with no labels and CC enabling not changed
+                            //console.log(empCesium.iconLabelOption);
+                            //console.log(empCesium.singlePointAltitudeRangeMode);
+                        }
+                        else
+                        {
+                            // Redraw all the symbols affected.
+                            for (singlePointKey in empCesium.singlePointCollection)
+                            {
+                                if (!empCesium.isSinglePointIdOnHoldPresent(singlePointKey))
+                                {
+                                    //empCesium.throttleMil2525IconLabelSet(empCesium.getSinglePoint(singlePointKey));
+                                    empCesium.throttleMil2525IconLabelSet(singlePointKey);
                                 }
                             }
                         }

--- a/src/sdk/core/api/cmapi/channel/handler/cmapi2.map.config.js
+++ b/src/sdk/core/api/cmapi/channel/handler/cmapi2.map.config.js
@@ -87,10 +87,13 @@ cmapi.channel.handler[cmapi.channel.names.CMAPI2_MAP_CONFIG] = {
           configItem[prop] = message.payload[0][prop];
         }
       }
-
+      
+      //add the label item to the configTransaction for v3
       if (labelItem) {
         labelTransaction.items.push(labelItem);
+        configTransaction.items.push(labelItem);
         labelTransaction.queue();
+        configTransaction.queue();
       }
 
       if (configItem) {

--- a/src/sdk/core/api/cmapi/channel/handler/cmapi2.map.config.js
+++ b/src/sdk/core/api/cmapi/channel/handler/cmapi2.map.config.js
@@ -90,13 +90,14 @@ cmapi.channel.handler[cmapi.channel.names.CMAPI2_MAP_CONFIG] = {
       
       //add the label item to the configTransaction for v3
       if (labelItem) {
+        configItem.milStdIconLabels = labelItem;
         labelTransaction.items.push(labelItem);
-        configTransaction.items.push(labelItem);
         labelTransaction.queue();
+        if(configItem){
+          configTransaction.items.push(configItem);
+        }
         configTransaction.queue();
-      }
-
-      if (configItem) {
+      }else if (configItem) {
         configTransaction.items.push(configItem);
         configTransaction.queue();
       }


### PR DESCRIPTION
Added the labelItem information to the config transactions. maintained the item transaction though for v2 compatibility unless otherwise directed.