### PR TITLE
experimental change: map lock state to SMART_MOTION instead of NO_MOT…

### DIFF
--- a/src/sdk/core/emp.editingManager.js
+++ b/src/sdk/core/emp.editingManager.js
@@ -269,7 +269,7 @@ emp.editingManager = function(args) {
         activeEditor.isControlPoint(featureId)) {
 
         mapLock = new emp.typeLibrary.Lock({
-          lock: emp3.api.enums.MapMotionLockEnum.NO_MOTION
+          lock: emp3.api.enums.MapMotionLockEnum.SMART_MOTION
         });
 
         // first lock the map in place so the map does not pan.


### PR DESCRIPTION
As a behavior when is SMART_MOTION expected vs completely locking the map? Editing I was expecting SMART_MOTION but it was set as NO_MOTION and I don't know if that was intentional or not.
