### PR TITLE
This partially fixes the cleanup of maps in the validation tool, over…

### DIFF
--- a/src/sdk/core/emp.instanceManager.js
+++ b/src/sdk/core/emp.instanceManager.js
@@ -103,7 +103,7 @@ emp.instanceManager = (function () {
 
     // needs the args.domContainer and args.instanceId;
     // Sets up the html and adds the divs for the map.  Show the loading screen.
-    instanceDomId = emp.ui.renderContainer({
+    emp.ui.renderContainer({
       instanceId: instanceId,
       domContainer: instanceDomId,
       recorder: args.recorder


### PR DESCRIPTION
overwriting the instanceDomID results in leaving the top level container in place which is not cleaned up by the instance manager
resolves #117